### PR TITLE
Fix to SwarpSetup

### DIFF
--- a/py_progs/Swarp.py
+++ b/py_progs/Swarp.py
@@ -5,10 +5,8 @@
 
 Create Combined images of the different filters in the field using swarp
 
-This can only be run after PrepFiles and SumFiles have benn run.    The routines here generate 
-inputs to run swarp which combines the individual CCD images into tile images.   This is normally
-carried out inside a Jupyter scripts.
-
+This can only be run after PrepFiles, SumFiles and SwarpSetup have benn run.    
+SwarpSetup will have prepared the run directories and the inpus.
 
 To run swarp from the command line (one must be in the normal run directory) since
 a particular directory structure is assumed here)
@@ -17,13 +15,15 @@ Usage:   Swarp.py [-all] [-bsub] field [tiles]
 
 where -all will cause swarp to be run on all 16 tiles.
 
-and   -bsub will cause swarp to be run on the files in background subtracted _b directories
+and   -bsub will cause swarp to be run in the DECAM_SWARP2 directories, and should
+be operating on files that are in background subtracted DECAM_PREP2 directories
 
 If one wants to run only 1 or a few tiles then the command will be something like
 
 Swarp.py LMC_c42  T01 T03 T05
 
-
+Notes:
+    It would be sensible to combine SetupSwarp and Swarp
 '''
 
 

--- a/py_progs/SwarpSetup.py
+++ b/py_progs/SwarpSetup.py
@@ -3,7 +3,7 @@
 
 '''
 
-Create Combined images of the different filters in the field using swarp
+Create inputs for Comineing images of the different filters in the field using swarp
 
 This can only be run after PrepFiles and SumFiles have benn run.    The routines here generate 
 inputs to run swarp which combines the individual CCD images into tile images.   This is normally
@@ -22,14 +22,17 @@ use the files ending in _sw.tab to set up run files
 
 and -bsub directs the routine to use data for which an addtioal backgound subtraction
 algorithm has been used.  In this case the Swarp commmands are written and to
-the DECam_SWARP/field/tile_b directory, so that data results which are
-background sutbracted and those that are not can be compared.
+the DECam_SWARP2/field/tile directory and the data are taken from the DECAM_PREP2/field/tile
+directory
 
 If one wants to run only 1 or a few tiles then the command will be something like
 
-Swarp.py LMC_c42  T01 T02 T03
+SwarpSetup.py LMC_c42  T01 T02 T03
 
+Note: 
 
+    In a future version it would make sense to combin this with Swarp.py and 
+    to adopt a switch just to do the setup or just to run the routine.
 
 
 '''
@@ -368,7 +371,11 @@ def create_swarp_command(field='LMC_c42',tile='T07',filt='Ha',exp=[800],defaults
     
     f=open(name,'w')
     for one in xxxx:
-        xname='%s/%s/%s/%s'% (PREPDIR,field,xtile,one['Filename'])
+        if bsub:
+            xname='%s2/%s/%s/%s'% (PREPDIR,field,xtile,one['Filename'])
+        else:
+            xname='%s/%s/%s/%s'% (PREPDIR,field,xtile,one['Filename'])
+
         f.write('%s\n' % xname)
     f.close()
     


### PR DESCRIPTION
Previously with the -bsub option SwaprSetup pointed to the files that were only had a mean background
per exposure subtracted.  With this change, it
creates input files that point to files in
DECam_PREP2 which is what was intended.