### PR TITLE
Bug38  - Prolems with mssing files when trying to SWARP background sutbracted images

### DIFF
--- a/py_progs/BackStats.py
+++ b/py_progs/BackStats.py
@@ -171,7 +171,7 @@ def calculate_one(file,xmatch_files,indir,calc_sigma_clipped=False,npix_min=100)
     including the mode, mean,median and std 
     in the overlap region
     '''
-    # print('Starting %s  with %d matches' % (file,len(xmatch_files)))
+    print('Starting %s  with %d matches' % (file,len(xmatch_files)))
     global ierror
 
     one=fits.open('%s/%s' % (indir,file))
@@ -241,6 +241,8 @@ def calculate_one(file,xmatch_files,indir,calc_sigma_clipped=False,npix_min=100)
                 records.append(one_record)
             else:
                 print('BackStats: Failed with (NaNs for) files %s and %s' % (file,xmatch_files[j]))
+        else:
+            print('BackStats: Failed with %d non_zero < %s pixels for files %s and %s' % (nonzero,npix_min,file,xmatch_files[j]))
 
         two.close()
         del two

--- a/py_progs/BackStats.py
+++ b/py_progs/BackStats.py
@@ -241,8 +241,8 @@ def calculate_one(file,xmatch_files,indir,calc_sigma_clipped=False,npix_min=100)
                 records.append(one_record)
             else:
                 print('BackStats: Failed with (NaNs for) files %s and %s' % (file,xmatch_files[j]))
-        else:
-            print('BackStats: Failed with %d non_zero < %s pixels for files %s and %s' % (nonzero,npix_min,file,xmatch_files[j]))
+        # else:
+        #     print('BackStats: Failed with %d non_zero < %s pixels for files %s and %s' % (nonzero,npix_min,file,xmatch_files[j]))
 
         two.close()
         del two

--- a/py_progs/MefSum.py
+++ b/py_progs/MefSum.py
@@ -149,6 +149,8 @@ def get_keyword(key,ext):
                 answer='N673'
             elif value.count('N708'):
                 answer='N708'
+            elif value.count('N501'):
+                answer='N501'
             elif value.count('r DECam'):
                 answer='r'
             elif value.count('g DECam'):

--- a/py_progs/MefSum.py
+++ b/py_progs/MefSum.py
@@ -151,6 +151,8 @@ def get_keyword(key,ext):
                 answer='N708'
             elif value.count('r DECam'):
                 answer='r'
+            elif value.count('g DECam'):
+                answer='g'
             else:
                 print('Could not identify filter from ',answer)
                 answer='Unknown'
@@ -218,12 +220,13 @@ def get_mef_overview(field='LMC_c45'):
 
     print('XXX :',len(good),len(bad))
 
-    xgood=xtab[good]
-    xgood.write('goo_%s.txt' % field ,format='ascii.fixed_width_two_line',overwrite=True)
-    ztab=ascii.read('goo_%s.txt' %field)
-    os.remove('goo_%s.txt' %field)
-    ztab.sort(['FILTER','EXPTIME'])
-    ztab.write('Summary/%s_mef.tab' % field ,format='ascii.fixed_width_two_line',overwrite=True)
+    if len(good)>0:
+        xgood=xtab[good]
+        xgood.write('goo_%s.txt' % field ,format='ascii.fixed_width_two_line',overwrite=True)
+        ztab=ascii.read('goo_%s.txt' %field)
+        os.remove('goo_%s.txt' %field)
+        ztab.sort(['FILTER','EXPTIME'])
+        ztab.write('Summary/%s_mef.tab' % field ,format='ascii.fixed_width_two_line',overwrite=True)
 
     if len(bad)>0:
         xbad=xtab[bad]

--- a/py_progs/SwarpEval.py
+++ b/py_progs/SwarpEval.py
@@ -86,7 +86,8 @@ def display_fits_image(image_file, scale='linear', invert=False, vmin=None, vmax
         scaled_data = -scaled_data
 
     # Create a figure and axes using wcsaxes
-    fig = plt.figure(1,figsize=(10, 10))  # Adjust the figure size as needed
+    fig = plt.figure(1)  
+    fig.set_size_inches(10,10,forward=True)
     fig.clf()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs_info, aspect='equal')  # Set the aspect ratio to 'equal'
     fig.add_axes(ax)

--- a/py_progs/SwarpSetup.py
+++ b/py_progs/SwarpSetup.py
@@ -57,7 +57,7 @@ PREPDIR=os.path.abspath('DECam_PREP')
 def get_sum_tab(field='LMC_c42',tile='T07'):
     '''
     Read a table that summarizes information about
-    the various files athat are used for a tile
+    the various files that are used for a tile
     
     The location of the table files is currently hardocaded
     '''
@@ -256,7 +256,10 @@ def create_swarp_command(field='LMC_c42',tile='T07',image='N673',defaults=xdefau
         else:
             xname='%s/%s/%s/%s'% (PREPDIR,field,tile,one['Filename'])
 
-        f.write('%s\n' % xname)
+        if os.path.isfile(xname):
+            f.write('%s\n' % xname)
+        else:
+            print('SwarpSetup: Warning: %s expected but not found' % xname)
     f.close()
     
     default_name='%s.default' % (root)


### PR DESCRIPTION
This addresses  issue #38 

The underlying problem was that there were images that did not overlap any other images being used to create a tile image.  Since these tiles did not overlap, there was no way to estimate what background should be subtracted, and so this file was not "processed" by BackStats (in the sense that there were no overlap fluxes for this file).

Now SwarpSetup checks to see that file exists in the appropriate directory before including it in the files to be swarped.  One should be aware that at some level this is a band-aide, and that kred is not currently designed to handle tiles in which their are disconnected "islands" of files.